### PR TITLE
removes log4j dependency, use internal logging instead

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,10 +48,6 @@ dependencies {
     // Let's use default JMX metric exporter from prometheus lib
     compile "io.prometheus:simpleclient_hotspot:${versions.prometheus_lib}"
 
-    // logging
-    shadow "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-    shadow "org.apache.logging.log4j:log4j-core:${versions.log4j}"
-
     testCompile "junit:junit:${versions.junit}"
 }
 

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,5 +1,4 @@
 prometheus_lib=0.2.0
-log4j=2.9.1
 
 # test dependencies
 junit=4.12

--- a/src/main/java/io/crate/jmx/MBeanPropertyCache.java
+++ b/src/main/java/io/crate/jmx/MBeanPropertyCache.java
@@ -22,9 +22,6 @@
 
 package io.crate.jmx;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import javax.management.ObjectName;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -40,9 +37,6 @@ import java.util.regex.Pattern;
  * https://github.com/prometheus/jmx_exporter/blob/master/collector/src/main/java/io/prometheus/jmx/JmxMBeanPropertyCache.java
  */
 class MBeanPropertyCache {
-
-    private static final Logger LOGGER = LogManager.getLogger(CrateCollector.class);
-
 
     private static final Pattern PROPERTY_PATTERN = Pattern.compile(
             "([^,=:\\*\\?]+)" + // Name - non-empty, anything but comma, equals, colon, star, or question mark
@@ -76,7 +70,6 @@ class MBeanPropertyCache {
         if (keyProperties == null) {
             keyProperties = new LinkedHashMap<>();
             String properties = mbeanName.getKeyPropertyListString();
-            LOGGER.debug("mbean properties: {} of objectName: {}", properties, mbeanName);
             Matcher match = PROPERTY_PATTERN.matcher(properties);
             while (match.lookingAt()) {
                 keyProperties.put(match.group(1), match.group(2));

--- a/src/main/java/io/crate/jmx/http/HttpReadyHandler.java
+++ b/src/main/java/io/crate/jmx/http/HttpReadyHandler.java
@@ -26,15 +26,12 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import io.crate.jmx.CrateCollector;
 import io.crate.jmx.MBeanAttributeValueStorage;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
 
 public class HttpReadyHandler implements HttpHandler {
 
-    private static final Logger LOGGER = LogManager.getLogger(HttpReadyHandler.class);
     private static final String READY_ATTR_NAME = "NodeStatus_Ready";
 
     private final CrateCollector crateCollector;
@@ -54,9 +51,6 @@ public class HttpReadyHandler implements HttpHandler {
         exchange.getResponseHeaders().set("Content-Length", "0");
 
         Object readyValue = attributeValueStorage.get(READY_ATTR_NAME);
-        if (LOGGER.isDebugEnabled()) {
-            LOGGER.debug("Ready value: {}", readyValue);
-        }
         if (readyValue instanceof Boolean) {
             Boolean boolVal = (Boolean) readyValue;
             if (boolVal) {


### PR DESCRIPTION
log4j is requiring a configuration which won’t be available yet at Crate
when the agent is starting.
also removes debug related loggings.