### PR TITLE
 adds custom metric recorder for every known crate mbean

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,0 +1,10 @@
+============
+Contributing
+============
+
+Thank you for your interest in contributing.
+
+Please see the CrateDB `contribution guide`_ for more information. Everything in
+the CrateDB contribution guide applies to this repository.
+
+.. _contribution guide: https://github.com/crate/crate/blob/master/CONTRIBUTING.rst

--- a/DEVELOPMENT.rst
+++ b/DEVELOPMENT.rst
@@ -1,0 +1,29 @@
+===============
+Developer Guide
+===============
+
+Building
+========
+
+This project uses Gradle_ as build tool.
+
+Gradle can be invoked like so::
+
+  $ ./gradlew
+
+The first time this command is executed, Gradle is downloaded and bootstrapped
+for you automatically.
+
+Building the JAR
+================
+
+Run::
+
+  $ ./gradlew buildJar
+
+Testing
+=======
+
+Run the unit and integration tests like so::
+
+  $ ./gradlew test

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Usage
 
 ::
 
-   export CRATE_JAVA_OPTS="-javaagent:<PATH_TO>/crate_jmx_agent-0.0.1.jar=<HOST>:<PORT>"
+   export CRATE_JAVA_OPTS="-javaagent:<PATH_TO>/crate_jmx_exporter-0.0.1.jar=<HOST>:<PORT>"
    ./bin/crate
 
 Afterwards the metrics can be fetched via HTTP under the configure host and port.

--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Usage
 
 ::
 
-   export CRATE_JAVA_OPTS="-javaagent:<PATH_TO>/crate_jmx_exporter-0.0.1.jar=<HOST>:<PORT>"
+   export CRATE_JAVA_OPTS="-javaagent:<PATH_TO>/crate_jmx_exporter-0.1.0.jar=<HOST>:<PORT>"
    ./bin/crate
 
 Afterwards the metrics can be fetched via HTTP under the configure host and port.

--- a/README.rst
+++ b/README.rst
@@ -28,3 +28,28 @@ Usage
    ./bin/crate
 
 Afterwards the metrics can be fetched via HTTP under the configure host and port.
+
+Contributing
+============
+
+This project is primarily maintained by `Crate.io`_, but we welcome community
+contributions!
+
+See the `developer docs`_ and the `contribution docs`_ for more information.
+
+Help
+====
+
+Looking for more help?
+
+- Check `StackOverflow`_ for common problems
+- Chat with us on `Slack`_
+- Get `paid support`_
+
+.. _contribution docs: CONTRIBUTING.rst
+.. _Crate.io: http://crate.io/
+.. _CrateDB: https://github.com/crate/crate
+.. _developer docs: DEVELOP.rst
+.. _paid support: https://crate.io/pricing/
+.. _Slack: https://crate.io/docs/support/slackin/
+.. _StackOverflow: https://stackoverflow.com/tags/crate

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ dependencies {
     testCompile ("com.carrotsearch.randomizedtesting:randomizedtesting-runner:${versions.randomizedtesting}") {
         exclude group: 'junit', module: 'junit'
     }
+    // gradle does not include tools.jar by default
+    testCompile files(org.gradle.internal.jvm.Jvm.current().getToolsJar())
 }
 
 
@@ -194,6 +196,7 @@ task buildJar(type: Jar, dependsOn: [classes]) {
 }
 tasks.buildJar.mustRunAfter jar // otherwise jar task would override shadowJar artifact
 
+test.dependsOn(dependsOn: [buildJar])   // JAR is needed by integration tests
 
 task wrapper(type: Wrapper) {
     gradleVersion = '4.5.1'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ Properties props = new Properties()
 props.load(new FileInputStream(file("gradle/version.properties")));
 ext.set("versions", props)
 
-project.version = "0.0.1"
+project.version = "0.1.0"
 
 allprojects {
     group = 'io.crate'

--- a/build.gradle
+++ b/build.gradle
@@ -158,7 +158,7 @@ forbiddenApisMain {
 }
 
 shadowJar {
-    baseName 'crate_jmx_agent'
+    baseName 'crate_jmx_exporter'
     classifier ''
     duplicatesStrategy 'fail'
     configurations = [project.configurations.compile]
@@ -180,14 +180,11 @@ shadowJar {
     relocate 'io.prometheus', 'io.crate.jmx.shade.io.prometheus'
 }
 
-
-
 jar.dependsOn(dependsOn: [shadowJar])
 jar {
     baseName 'crate_jmx_exporter'
     actions = [] // Do nothing, build shadedJar instead
 }
-
 
 task buildJar(type: Jar, dependsOn: [classes]) {
     doLast {

--- a/src/main/java/io/crate/jmx/Agent.java
+++ b/src/main/java/io/crate/jmx/Agent.java
@@ -31,6 +31,12 @@ import io.prometheus.client.hotspot.DefaultExports;
 import java.lang.instrument.Instrumentation;
 import java.net.InetSocketAddress;
 
+/**
+ * Java Agent implementation for exposing CrateDB JMX metrics via HTTP.
+ *
+ * Derived from
+ * https://github.com/prometheus/jmx_exporter/blob/master/jmx_prometheus_javaagent/src/main/java/io/prometheus/jmx/JavaAgent.java.
+ */
 public class Agent {
 
     static HttpServer SERVER;

--- a/src/main/java/io/crate/jmx/recorder/MetricSampleConsumer.java
+++ b/src/main/java/io/crate/jmx/recorder/MetricSampleConsumer.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import io.prometheus.client.Collector;
+
+@FunctionalInterface
+public interface MetricSampleConsumer {
+
+    void accept(Collector.MetricFamilySamples.Sample sample, Collector.Type type, String help);
+}

--- a/src/main/java/io/crate/jmx/recorder/NodeStatus.java
+++ b/src/main/java/io/crate/jmx/recorder/NodeStatus.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import io.prometheus.client.Collector;
+
+import java.util.Collections;
+
+public class NodeStatus implements Recorder {
+
+    static final String MBEAN_NAME = "NodeStatus";
+
+    @Override
+    public boolean recordBean(String domain,
+                              String attrName,
+                              Number beanValue,
+                              MetricSampleConsumer metricSampleConsumer) {
+        if (attrName.equalsIgnoreCase("Ready")) {
+            String fullname = domain + "_ready";
+            metricSampleConsumer.accept(
+                    new Collector.MetricFamilySamples.Sample(
+                            fullname,
+                            Collections.emptyList(),
+                            Collections.emptyList(),
+                            beanValue.doubleValue()),
+                    Collector.Type.GAUGE,
+                    "Readiness of processing SQL statements.");
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/io/crate/jmx/recorder/QueryStats.java
+++ b/src/main/java/io/crate/jmx/recorder/QueryStats.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import io.prometheus.client.Collector;
+
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class QueryStats implements Recorder {
+
+    static final String MBEAN_NAME = "QueryStats";
+
+    private static final Pattern QUERIES_PER_SECONDS_PATTERN = Pattern.compile("(.+)QueryFrequency");
+    private static final Pattern QUERIES_DURATION_PATTERN = Pattern.compile("(.+)QueryAverageDuration");
+
+    @Override
+    public boolean recordBean(String domain,
+                              String attrName,
+                              Number beanValue,
+                              MetricSampleConsumer metricSampleConsumer) {
+        Matcher matcher = QUERIES_PER_SECONDS_PATTERN.matcher(attrName);
+        if (matcher.matches()) {
+            recordBean(
+                    domain,
+                    "queries",
+                    matcher.group(1),
+                    beanValue,
+                    "Queries per second for a given query type.",
+                    metricSampleConsumer);
+            return true;
+        }
+        matcher = QUERIES_DURATION_PATTERN.matcher(attrName);
+        if (matcher.matches()) {
+            recordBean(
+                    domain,
+                    "query_duration_seconds",
+                    matcher.group(1),
+                    beanValue,
+                    "The average query duration for a given query type.",
+                    metricSampleConsumer);
+            return true;
+        }
+        return false;
+    }
+
+    private static void recordBean(String domain,
+                                   String attrName,
+                                   String labelValue,
+                                   Number beanValue,
+                                   String help,
+                                   MetricSampleConsumer metricSampleConsumer) {
+        String fullname = domain + "_" + attrName;
+        metricSampleConsumer.accept(
+                new Collector.MetricFamilySamples.Sample(
+                        fullname,
+                        Collections.singletonList("query"),
+                        Collections.singletonList(labelValue),
+                        beanValue.doubleValue()),
+                Collector.Type.GAUGE,
+                help);
+    }
+}

--- a/src/main/java/io/crate/jmx/recorder/Recorder.java
+++ b/src/main/java/io/crate/jmx/recorder/Recorder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+public interface Recorder {
+
+    /**
+     * Adds a MBean attribute as a metric sample to the given consumer.
+     */
+    boolean recordBean(String domain, String attrName, Number beanValue, MetricSampleConsumer metricSampleConsumer);
+}

--- a/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
+++ b/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * CrateDB MBean to {@link Recorder} registry for custom JMX metric recording.
+ */
+public final class RecorderRegistry {
+
+    private static Map<String, Recorder> REGISTRY = new HashMap<>();
+
+    static {
+        REGISTRY.put(QueryStats.MBEAN_NAME, new QueryStats());
+        REGISTRY.put(NodeStatus.MBEAN_NAME, new NodeStatus());
+    }
+
+    public static Recorder get(String name) {
+        return REGISTRY.get(name);
+    }
+
+    private RecorderRegistry() {
+    }
+}

--- a/src/test/java/io/crate/jmx/CrateCollectorTest.java
+++ b/src/test/java/io/crate/jmx/CrateCollectorTest.java
@@ -1,10 +1,34 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.jmx;
 
 import io.prometheus.client.Collector;
 import io.prometheus.client.CollectorRegistry;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
+import javax.management.InstanceNotFoundException;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import java.lang.management.ManagementFactory;
@@ -26,6 +50,15 @@ public class CrateCollectorTest {
         mbeanServer = ManagementFactory.getPlatformMBeanServer();
     }
 
+    @After
+    public void unregisterMBean() throws Exception {
+        CollectorRegistry.defaultRegistry.clear();
+        try {
+            mbeanServer.unregisterMBean(new ObjectName(CrateDummyStatus.NAME));
+        } catch (InstanceNotFoundException ignored) {
+        }
+    }
+
     @Test
     public void testNoCrateMBeanFound() {
         CollectorRegistry registry = CollectorRegistry.defaultRegistry;
@@ -34,7 +67,34 @@ public class CrateCollectorTest {
     }
 
     @Test
-    public void testCrateMBeanFoundAndAttributesRead() throws Exception {
+    public void testQueryStatsMBean() throws Exception {
+        mbeanServer.registerMBean(new QueryStats(), new ObjectName(QueryStats.NAME));
+
+        CollectorRegistry registry = CollectorRegistry.defaultRegistry;
+        // metrics are collected while iterating on registered ones
+        Enumeration<Collector.MetricFamilySamples> metrics = registry.metricFamilySamples();
+        assertThat(metrics.hasMoreElements(), is(true));
+
+        Collector.MetricFamilySamples samples = metrics.nextElement();
+        assertThat(samples.name, is("crate_queries"));
+
+        assertThat(samples.samples.size(), is(1));
+        Collector.MetricFamilySamples.Sample sample = samples.samples.get(0);
+        assertThat(sample.value, is(2.0));
+        assertThat(sample.labelNames, hasItem(is("query")));
+        assertThat(sample.labelValues, hasItem(is("Select")));
+
+        samples = metrics.nextElement();
+        assertThat(samples.name, is("crate_query_duration_seconds"));
+        assertThat(samples.samples.size(), is(1));
+        sample = samples.samples.get(0);
+        assertThat(sample.value, is(1.2));
+        assertThat(sample.labelNames, hasItem(is("query")));
+        assertThat(sample.labelValues, hasItem(is("Select")));
+    }
+
+    @Test
+    public void testCrateMBeanFoundAndAttributesReadAsDefault() throws Exception {
         mbeanServer.registerMBean(new CrateDummyStatus(), new ObjectName(CrateDummyStatus.NAME));
 
         CollectorRegistry registry = CollectorRegistry.defaultRegistry;
@@ -42,24 +102,21 @@ public class CrateCollectorTest {
         Enumeration<Collector.MetricFamilySamples> metrics = registry.metricFamilySamples();
         assertThat(metrics.hasMoreElements(), is(true));
 
-        // MBean's attributes are added in alphabetic order
-        // first property, a long.
         Collector.MetricFamilySamples samples = metrics.nextElement();
-        assertThat(samples.name, is("crate_dummy_status_stats"));
+        assertThat(samples.name, is("crate_dummy_status_something_enabled"));
 
         Collector.MetricFamilySamples.Sample sample = samples.samples.get(0);
-        assertThat(sample.value, is(123.0));
-        assertThat(sample.labelNames, hasItem(is("label")));
-        assertThat(sample.labelValues, hasItem(is("Select")));
+        assertThat(sample.value, is(1.0));
+        assertThat(sample.labelNames.size(), is(0));
+        assertThat(sample.labelValues.size(), is(0));
 
-        // second property, a boolean
         samples = metrics.nextElement();
-        assertThat(samples.name, is("crate_dummy_status_enabled"));
+        assertThat(samples.name, is("crate_dummy_status_select_stats"));
 
         sample = samples.samples.get(0);
-        assertThat(sample.value, is(1.0));
-        assertThat(sample.labelNames, hasItem(is("label")));
-        assertThat(sample.labelValues, hasItem(is("Something: true")));
+        assertThat(sample.value, is(123.0));
+        assertThat(sample.labelNames.size(), is(0));
+        assertThat(sample.labelValues.size(), is(0));
     }
 
     @Test
@@ -76,6 +133,26 @@ public class CrateCollectorTest {
         dummyBean.boolValue = false;
         crateCollector.collect();
         assertThat(beanAttributeValueStorage.get("DummyStatus_SomethingEnabled"), is(false));
+    }
+
+    public interface QueryStatsMBean {
+
+        double getSelectQueryFrequency();
+        double getSelectQueryAverageDuration();
+    }
+
+    private static class QueryStats implements QueryStatsMBean {
+
+        static final String NAME = "io.crate.monitoring:type=QueryStats";
+        @Override
+        public double getSelectQueryFrequency() {
+            return 2;
+        }
+
+        @Override
+        public double getSelectQueryAverageDuration() {
+            return 1.2;
+        }
     }
 
     public interface CrateDummyStatusMBean {

--- a/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
@@ -115,7 +115,7 @@ public abstract class AbstractITest extends RandomizedTest {
             throw new RuntimeException("Cannot list files while searching the agent jar");
         }
         for (File file : files) {
-            if (file.getName().contains("crate_jmx_agent")) {
+            if (file.getName().contains("crate_jmx_exporter")) {
                 return file;
             }
         }

--- a/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
@@ -1,3 +1,25 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.jmx.integrationtests;
 
 import com.carrotsearch.randomizedtesting.RandomizedTest;
@@ -78,7 +100,7 @@ public abstract class AbstractITest extends RandomizedTest {
 
     private static void attachAgent(String pid) throws Exception {
         File agentJar = findAgentJar();
-        String options = String.format(":%d", JMX_HTTP_PORT);
+        String options = String.format("%d", JMX_HTTP_PORT);
         VirtualMachine vm = VirtualMachine.attach(pid);
         vm.loadAgent(agentJar.getAbsolutePath(), options);
     }

--- a/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
@@ -1,5 +1,28 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
 package io.crate.jmx.integrationtests;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
@@ -9,11 +32,107 @@ import static org.hamcrest.CoreMatchers.is;
 
 public class MetricsITest extends AbstractITest {
 
-    @Test
-    public void testMetricEndpoint() throws Exception {
+    private static String METRICS_RESPONSE;
+
+    @BeforeClass
+    public static void fetchMetrics() throws Exception {
         HttpURLConnection connection = (HttpURLConnection) randomJmxUrlFromServers("/metrics").openConnection();
         assertThat(connection.getResponseCode(), is(200));
-        String res = parseResponse(connection.getInputStream());
-        assertThat(res, containsString("crate_query_stats_query_average_duration{label=\"Select\",} 0.0\n"));
+        METRICS_RESPONSE = parseResponse(connection.getInputStream());
+    }
+
+    @Test
+    public void testQueryStatsMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("crate_query_duration_seconds{query=\"Select\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_query_duration_seconds{query=\"Update\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_query_duration_seconds{query=\"Delete\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_query_duration_seconds{query=\"Insert\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_query_duration_seconds{query=\"Overall\",} 0.0\n"));
+
+        assertThat(METRICS_RESPONSE, containsString("crate_queries{query=\"Select\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_queries{query=\"Update\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_queries{query=\"Delete\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_queries{query=\"Insert\",} 0.0\n"));
+        assertThat(METRICS_RESPONSE, containsString("crate_queries{query=\"Overall\",}"));
+    }
+
+    @Test
+    public void testNodeStatusMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("crate_ready 1.0\n"));
+    }
+
+    @Test
+    public void testJvmVersionMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("jvm_info{version="));
+    }
+
+    @Test
+    public void testJvmMemoryMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_used{area=\"heap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_used{area=\"nonheap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_committed{area=\"heap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_committed{area=\"nonheap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_max{area=\"heap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_max{area=\"nonheap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_init{area=\"heap\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_bytes_init{area=\"nonheap\",}"));
+
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"Code Cache\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"Metaspace\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"Compressed Class Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"Par Eden Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"Par Survivor Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_used{pool=\"CMS Old Gen\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"Code Cache\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"Metaspace\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"Compressed Class Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"Par Eden Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"Par Survivor Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_committed{pool=\"CMS Old Gen\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"Code Cache\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"Metaspace\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"Compressed Class Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"Par Eden Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"Par Survivor Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_max{pool=\"CMS Old Gen\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"Code Cache\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"Metaspace\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"Compressed Class Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"Par Eden Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"Par Survivor Space\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_memory_pool_bytes_init{pool=\"CMS Old Gen\",}"));
+    }
+
+    @Test
+    public void testJvmThreadsMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_current"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_daemon"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_peak"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_started_total"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_deadlocked"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_threads_deadlocked_monitor"));
+    }
+
+    @Test
+    public void testJvmGcMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("jvm_gc_collection_seconds_count{gc=\"ParNew\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_gc_collection_seconds_sum{gc=\"ParNew\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_gc_collection_seconds_count{gc=\"ConcurrentMarkSweep\",}"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_gc_collection_seconds_sum{gc=\"ConcurrentMarkSweep\",}"));
+    }
+
+    @Test
+    public void testJvmClassLoadingMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("jvm_classes_loaded"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_classes_loaded_total"));
+        assertThat(METRICS_RESPONSE, containsString("jvm_classes_unloaded_total"));
+    }
+
+    @Test
+    public void testJvmProcessMetrics() {
+        assertThat(METRICS_RESPONSE, containsString("process_cpu_seconds_total"));
+        assertThat(METRICS_RESPONSE, containsString("process_start_time_seconds"));
+        assertThat(METRICS_RESPONSE, containsString("process_open_fds"));
+        assertThat(METRICS_RESPONSE, containsString("process_max_fds"));
     }
 }


### PR DESCRIPTION
This makes it possible to have better metric names and labels, unknown crate metrics will use a default sample recorder.

Example output:
```
# HELP crate_ready Readiness of processing SQL statements.
# TYPE crate_ready gauge
crate_ready 1.0
# HELP crate_queries Queries per second for a given query type.
# TYPE crate_queries gauge
crate_queries{query="Select",} 0.0
crate_queries{query="Insert",} 0.0
crate_queries{query="Update",} 0.0
crate_queries{query="Delete",} 0.0
crate_queries{query="Overall",} 1.2254901960784315
# HELP crate_query_duration_seconds The average query duration for a given query type.
# TYPE crate_query_duration_seconds gauge
crate_query_duration_seconds{query="Select",} 0.0
crate_query_duration_seconds{query="Insert",} 0.0
crate_query_duration_seconds{query="Update",} 0.0
crate_query_duration_seconds{query="Delete",} 0.0
crate_query_duration_seconds{query="Overall",} 0.0
```

Additionally some smaller cleanups were made, see commits.