### PR TITLE
clear the existing metrics map before collecting

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,0 +1,10 @@
+=====================================
+ Changes for Crate JMX HTTP Exporter
+=====================================
+
+Unreleased
+==========
+
+- Fixed an issue which resulted in duplicate crate metrics output when
+  requesting the metrics multiple times.
+

--- a/src/main/java/io/crate/jmx/CrateCollector.java
+++ b/src/main/java/io/crate/jmx/CrateCollector.java
@@ -80,6 +80,7 @@ public class CrateCollector extends Collector {
 
     @Override
     public List<MetricFamilySamples> collect() {
+        metricFamilySamplesMap.clear();
         for (ObjectName mBeanName : resolveMBeans()) {
             try {
                 MBeanInfo mBeanInfo = beanConn.getMBeanInfo(mBeanName);

--- a/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
@@ -29,6 +29,7 @@ import java.net.HttpURLConnection;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 
 public class MetricsITest extends AbstractITest {
 
@@ -134,5 +135,15 @@ public class MetricsITest extends AbstractITest {
         assertThat(METRICS_RESPONSE, containsString("process_start_time_seconds"));
         assertThat(METRICS_RESPONSE, containsString("process_open_fds"));
         assertThat(METRICS_RESPONSE, containsString("process_max_fds"));
+    }
+
+    @Test
+    public void testRequestingMultipleTimesDoesNotResultInDuplicateMetrics() throws Exception {
+        HttpURLConnection connection = (HttpURLConnection) randomJmxUrlFromServers("/metrics").openConnection();
+        assertThat(connection.getResponseCode(), is(200));
+        String response = parseResponse(connection.getInputStream());
+
+        assertThat(response, containsString("crate_ready 1.0\n"));
+        assertThat(response, not(containsString("crate_ready 1.0\ncrate_ready 1.0\n")));
     }
 }


### PR DESCRIPTION
collect() will always collect all found metrics everytime, 
so the map must be cleared before.
otherwise the same metric samples will be stored and responded multiple
times.