### PR TITLE
add support for CrateDB’s `ThreadPools` MXBean

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,8 +5,11 @@
 Unreleased
 ==========
 
+- Added a new metric under ``/metrics`` endpoint which exposes statistics of
+  each thread pool.
+
 - Added a new metric under ``/metrics`` endpoint which exposes the number of
-  open and total connections per protocol
+  open and total connections per protocol.
 
 2018/04/16 0.2.0
 ================

--- a/src/main/java/io/crate/jmx/recorder/Recorder.java
+++ b/src/main/java/io/crate/jmx/recorder/Recorder.java
@@ -22,6 +22,8 @@
 
 package io.crate.jmx.recorder;
 
+import javax.management.openmbean.CompositeData;
+
 public interface Recorder {
 
     /**
@@ -34,6 +36,13 @@ public interface Recorder {
      */
     boolean recordBean(String domain, String attrName, String beanValue, MetricSampleConsumer metricSampleConsumer);
 
+    default boolean recordBean(String domain,
+                               String attrName,
+                               CompositeData beanValue,
+                               MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
+                                                " cannot be called with CompositeData bean value");
+    }
 
     /**
      * Clears any internal structures before new collect()

--- a/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
+++ b/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
@@ -37,6 +37,7 @@ public final class RecorderRegistry {
         REGISTRY.put(NodeStatus.MBEAN_NAME, new NodeStatus());
         REGISTRY.put(NodeInfo.MBEAN_NAME, new NodeInfo());
         REGISTRY.put(Connections.MBEAN_NAME, new Connections());
+        REGISTRY.put(ThreadPools.MBEAN_NAME, new ThreadPools());
     }
 
     public static Recorder get(String name) {

--- a/src/main/java/io/crate/jmx/recorder/ThreadPools.java
+++ b/src/main/java/io/crate/jmx/recorder/ThreadPools.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import io.prometheus.client.Collector;
+
+import javax.management.openmbean.CompositeData;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+
+public class ThreadPools implements Recorder {
+
+    static final String MBEAN_NAME = "ThreadPools";
+
+    @Override
+    public boolean recordBean(String domain,
+                              String attrName,
+                              Number beanValue,
+                              MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(ThreadPools.class.getSimpleName() + " cannot be called with Numeric " +
+                                                "bean value");
+    }
+
+    @Override
+    public boolean recordBean(String domain,
+                              String attrName,
+                              String beanValue,
+                              MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(ThreadPools.class.getSimpleName() + " cannot be called with String " +
+                                                "bean value");
+    }
+
+    @Override
+    public boolean recordBean(String domain,
+                              String attrName,
+                              CompositeData beanValue,
+                              MetricSampleConsumer metricSampleConsumer) {
+        Set<String> names = beanValue.getCompositeType().keySet();
+        String poolName = ((String) beanValue.get("name")).toLowerCase(Locale.ENGLISH);
+
+        for (String propertyName : names) {
+            Object value = beanValue.get(propertyName);
+            if ((value instanceof Number) == false) {
+                // we're not interested in non-numeric values e.g. pool name
+                continue;
+            }
+
+            metricSampleConsumer.accept(
+                    new Collector.MetricFamilySamples.Sample(
+                            domain + '_' + "threadpools",
+                            Arrays.asList("name", "property"),
+                            Arrays.asList(poolName, propertyName),
+                            ((Number) value).longValue()
+                    ),
+                    Collector.Type.GAUGE,
+                    "Statistics of thread pools"
+            );
+        }
+        return true;
+    }
+}

--- a/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
@@ -43,7 +43,7 @@ import java.util.Random;
 
 public abstract class AbstractITest extends RandomizedTest {
 
-    private static final String LATEST_URL = "https://cdn.crate.io/downloads/releases/nightly/crate-3.1.0-201806180203-96e5f32.tar.gz";
+    private static final String LATEST_URL = "https://cdn.crate.io/downloads/releases/nightly/crate-3.1.0-201807240202-e94076d.tar.gz";
     private static String[] CRATE_VERSIONS = new String[]{"latest"};
 
     private static final int JMX_HTTP_PORT = 17071;

--- a/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
@@ -26,6 +26,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
@@ -65,6 +67,20 @@ public class MetricsITest extends AbstractITest {
         assertMetricValue("crate_connections{protocol=\"http\",property=\"open\",} ");
         assertMetricValue("crate_connections{protocol=\"http\",property=\"total\",} ");
         assertMetricValue("crate_connections{protocol=\"transport\",property=\"open\",} ");
+    }
+
+    @Test
+    public void testThreadPoolsMetrics() {
+        List<String> poolNames = Arrays.asList(
+                "generic", "search", "get", "index", "snapshot", "management",
+                "listener", "flush", "refresh", "force_merge", "fetch_shard_started", "fetch_shard_store");
+        List<String> properties = Arrays.asList(
+                "poolSize", "largestPoolSize", "queueSize", "active", "completed", "rejected");
+        for (String poolName : poolNames) {
+            for (String property : properties) {
+                assertMetricValue("crate_threadpools{name=\""+poolName+"\",property=\""+property+"\",} ");
+            }
+        }
     }
 
     private void assertMetricValue(String metricString) {


### PR DESCRIPTION
The included integration test will only succeed if the latest nightly contains the `ThreadPools` JMX MXBean, see https://github.com/crate/crate/pull/7532.
Also the `LATEST` uri defined at the intergation test suite must be updated to point to the latest nightly.