### PR TITLE
add support for the `CircuitBreakers` MXBean

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+- Added a new metric under ``/metrics`` endpoint which exposes statistics of
+  each circuit breaker.
+
 2018/08/03 0.3.0
 ================
 

--- a/src/main/java/io/crate/jmx/recorder/CircuitBreakers.java
+++ b/src/main/java/io/crate/jmx/recorder/CircuitBreakers.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to Crate under one or more contributor license agreements.
+ * See the NOTICE file distributed with this work for additional
+ * information regarding copyright ownership.  Crate licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.  You may
+ * obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+ * implied.  See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ * However, if you have executed another commercial license agreement
+ * with Crate these terms will supersede the license and you may use the
+ * software solely pursuant to the terms of the relevant commercial
+ * agreement.
+ */
+
+package io.crate.jmx.recorder;
+
+import io.prometheus.client.Collector;
+
+import javax.management.openmbean.CompositeData;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Set;
+
+public class CircuitBreakers implements Recorder {
+
+    static final String MBEAN_NAME = "CircuitBreakers";
+
+    @Override
+    public boolean recordBean(String domain, String attrName, Number beanValue, MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(CircuitBreakers.class.getSimpleName() + " cannot be called with Numeric " +
+                                                "bean value");
+    }
+
+    @Override
+    public boolean recordBean(String domain, String attrName, CompositeData beanValue, MetricSampleConsumer metricSampleConsumer) {
+        Set<String> names = beanValue.getCompositeType().keySet();
+        String name = ((String) beanValue.get("name")).toLowerCase(Locale.ENGLISH);
+
+        for (String propertyName : names) {
+            Object value = beanValue.get(propertyName);
+            if ((value instanceof Number) == false) {
+                // we're not interested in non-numeric values e.g. name
+                continue;
+            }
+
+            metricSampleConsumer.accept(
+                    new Collector.MetricFamilySamples.Sample(
+                            domain + '_' + "circuitbreakers",
+                            Arrays.asList("name", "property"),
+                            Arrays.asList(name, propertyName),
+                            ((Number) value).longValue()
+                    ),
+                    Collector.Type.GAUGE,
+                    "Statistics of circuit breakers"
+            );
+        }
+        return true;
+    }
+}

--- a/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
+++ b/src/main/java/io/crate/jmx/recorder/RecorderRegistry.java
@@ -38,6 +38,7 @@ public final class RecorderRegistry {
         REGISTRY.put(NodeInfo.MBEAN_NAME, new NodeInfo());
         REGISTRY.put(Connections.MBEAN_NAME, new Connections());
         REGISTRY.put(ThreadPools.MBEAN_NAME, new ThreadPools());
+        REGISTRY.put(CircuitBreakers.MBEAN_NAME, new CircuitBreakers());
     }
 
     public static Recorder get(String name) {

--- a/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/AbstractITest.java
@@ -43,7 +43,7 @@ import java.util.Random;
 
 public abstract class AbstractITest extends RandomizedTest {
 
-    private static final String LATEST_URL = "https://cdn.crate.io/downloads/releases/nightly/crate-3.1.0-201807240202-e94076d.tar.gz";
+    private static final String LATEST_URL = "https://cdn.crate.io/downloads/releases/nightly/crate-3.1.0-201808100203-a254e2f.tar.gz";
     private static String[] CRATE_VERSIONS = new String[]{"latest"};
 
     private static final int JMX_HTTP_PORT = 17071;

--- a/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
+++ b/src/test/java/io/crate/jmx/integrationtests/MetricsITest.java
@@ -83,12 +83,25 @@ public class MetricsITest extends AbstractITest {
         }
     }
 
+    @Test
+    public void testCircuitBreakersMetrics() {
+        List<String> names = Arrays.asList(
+                "parent", "query", "jobs_log", "operations_log", "fielddata", "request", "in_flight_requests");
+        List<String> properties = Arrays.asList(
+                "limit", "used", "trippedCount", "overhead");
+        for (String name : names) {
+            for (String property : properties) {
+                assertMetricValue("crate_circuitbreakers{name=\""+name+"\",property=\""+property+"\",} ");
+            }
+        }
+    }
+
     private void assertMetricValue(String metricString) {
         int startIdx = METRICS_RESPONSE.indexOf(metricString);
         assertThat(metricString + " not found in response", startIdx, greaterThanOrEqualTo(0));
         int endIdx = METRICS_RESPONSE.indexOf("\n", startIdx);
         String metricValueStr = METRICS_RESPONSE.substring(startIdx + metricString.length(), endIdx);
-        assertThat(metricValueStr.matches("\\d+.\\d+"), is(true));
+        assertThat(metricValueStr.matches("\\d+.\\d+(E\\d)?"), is(true));
     }
 
     @Test


### PR DESCRIPTION
integration tests will only pass after https://github.com/crate/crate/pull/7578 is included at the latest nightly and the nightly URI is updated. so do not merge yet.