### PR TITLE
Don’t log ignored NodeInfo MBean string attributes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+- Don't create log warning entries for ``crate_node_info`` attributes that are
+  ignored by intend.
+
 - Added a new metric under ``/metrics`` endpoint which exposes statistics of
   each circuit breaker.
 

--- a/src/main/java/io/crate/jmx/CrateCollector.java
+++ b/src/main/java/io/crate/jmx/CrateCollector.java
@@ -172,7 +172,8 @@ public class CrateCollector extends Collector {
                     (Boolean) beanValue ? 1 : 0);
         } else if (beanValue instanceof CompositeData) {
             recordCompositeDataMBeanValue(attrName, mBeanName, (CompositeData) beanValue);
-        } else {
+        } else if ((beanValue instanceof String) == false) {
+            // only log on non-string values, string values are ignored by intend
             LOGGER.log(Level.SEVERE, "Ignoring unsupported bean: " + mBeanName + "_" + attrName + ": " + beanValue);
         }
     }

--- a/src/main/java/io/crate/jmx/recorder/CircuitBreakers.java
+++ b/src/main/java/io/crate/jmx/recorder/CircuitBreakers.java
@@ -34,12 +34,6 @@ public class CircuitBreakers implements Recorder {
     static final String MBEAN_NAME = "CircuitBreakers";
 
     @Override
-    public boolean recordBean(String domain, String attrName, Number beanValue, MetricSampleConsumer metricSampleConsumer) {
-        throw new UnsupportedOperationException(CircuitBreakers.class.getSimpleName() + " cannot be called with Numeric " +
-                                                "bean value");
-    }
-
-    @Override
     public boolean recordBean(String domain, String attrName, CompositeData beanValue, MetricSampleConsumer metricSampleConsumer) {
         Set<String> names = beanValue.getCompositeType().keySet();
         String name = ((String) beanValue.get("name")).toLowerCase(Locale.ENGLISH);

--- a/src/main/java/io/crate/jmx/recorder/Recorder.java
+++ b/src/main/java/io/crate/jmx/recorder/Recorder.java
@@ -29,7 +29,13 @@ public interface Recorder {
     /**
      * Adds a MBean attribute as a metric sample to the given consumer.
      */
-    boolean recordBean(String domain, String attrName, Number beanValue, MetricSampleConsumer metricSampleConsumer);
+    default boolean recordBean(String domain,
+                               String attrName,
+                               Number beanValue,
+                               MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
+                                                " cannot be called with Numeric bean value");
+    }
 
     default boolean recordBean(String domain,
                                String attrName,

--- a/src/main/java/io/crate/jmx/recorder/ThreadPools.java
+++ b/src/main/java/io/crate/jmx/recorder/ThreadPools.java
@@ -36,15 +36,6 @@ public class ThreadPools implements Recorder {
     @Override
     public boolean recordBean(String domain,
                               String attrName,
-                              Number beanValue,
-                              MetricSampleConsumer metricSampleConsumer) {
-        throw new UnsupportedOperationException(ThreadPools.class.getSimpleName() + " cannot be called with Numeric " +
-                                                "bean value");
-    }
-
-    @Override
-    public boolean recordBean(String domain,
-                              String attrName,
                               CompositeData beanValue,
                               MetricSampleConsumer metricSampleConsumer) {
         Set<String> names = beanValue.getCompositeType().keySet();

--- a/src/test/java/io/crate/jmx/CrateCollectorTest.java
+++ b/src/test/java/io/crate/jmx/CrateCollectorTest.java
@@ -198,6 +198,7 @@ public class CrateCollectorTest {
         Collector.MetricFamilySamples.Sample clusterStateSample = clusterStateVersionSample.samples.get(0);
         assertThat(clusterStateSample.value, is(3.0));
 
+        // all string attributes of the NodeInfo MBean are ignored by intend, so no more elements must exists.
         assertThat(metrics.hasMoreElements(), is(false));
     }
 
@@ -332,6 +333,8 @@ public class CrateCollectorTest {
     public interface CrateDummyNodeInfoMBean {
 
         long getClusterStateVersion();
+
+        String getNodeId();
     }
 
     private static class CrateDummyNodeInfo implements CrateDummyNodeInfoMBean {
@@ -341,6 +344,11 @@ public class CrateCollectorTest {
         @Override
         public long getClusterStateVersion() {
             return 3L;
+        }
+
+        @Override
+        public String getNodeId() {
+            return "node1";
         }
     }
 


### PR DESCRIPTION
These attributes are ignored by intend and should not result
in SERVE log entries.
Follow up of https://github.com/crate/jmx_exporter/commit/d306eff1c414f77e16507282278a10a1980678c2