### PR TITLE
Add shard information to node info metrics

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+- Added new shard related metrics to ``NodeInfo`` reporting detailed information
+  about the shards located on the node.
+
 Breaking changes
 ================
 

--- a/src/main/java/io/crate/jmx/recorder/Recorder.java
+++ b/src/main/java/io/crate/jmx/recorder/Recorder.java
@@ -45,6 +45,14 @@ public interface Recorder {
                                                 " cannot be called with CompositeData bean value");
     }
 
+    default boolean recordBean(String domain,
+                               String attrName,
+                               CompositeData[] beanValue,
+                               MetricSampleConsumer metricSampleConsumer) {
+        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
+                " cannot be called with CompositeData[] bean value");
+    }
+
     /**
      * Clears any internal structures before new collect()
      */


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This adds the following shard specific metrices:

```
crate_node(name=shard_stats, property=primaries) 1 
crate_node(name=shard_stats, property=replicas) 2
crate_node(name=shard_stats, property=total) 3
crate_node(name=shard_stats, property=unassigned) 0
crate_node(name=shard_stats, property=recovering) 1

crate_node(name=shard_info, property=size, id=1, table=test, partition_ident=p1) 100
crate_node(name=shard_info, property=size, id=2, table=test, partition_ident=p1) 1000
crate_node(name=shard_info, property=size, id=3, table=test, partition_ident=p1) 500
```


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
