### PR TITLE
Make Recorder ignore unsupported jmx datatypes by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,9 @@
 Unreleased
 ==========
 
+- Made sure unsupported jmx datatypes are only logged and not cause to stop the
+  the agent.
+
 - Added new shard related metrics to ``NodeInfo`` reporting detailed information
   about the shards located on the node.
 

--- a/src/main/java/io/crate/jmx/recorder/Recorder.java
+++ b/src/main/java/io/crate/jmx/recorder/Recorder.java
@@ -33,24 +33,21 @@ public interface Recorder {
                                String attrName,
                                Number beanValue,
                                MetricSampleConsumer metricSampleConsumer) {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
-                                                " cannot be called with Numeric bean value");
+        return false;
     }
 
     default boolean recordBean(String domain,
                                String attrName,
                                CompositeData beanValue,
                                MetricSampleConsumer metricSampleConsumer) {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
-                                                " cannot be called with CompositeData bean value");
+        return false;
     }
 
     default boolean recordBean(String domain,
                                String attrName,
                                CompositeData[] beanValue,
                                MetricSampleConsumer metricSampleConsumer) {
-        throw new UnsupportedOperationException(this.getClass().getSimpleName() +
-                " cannot be called with CompositeData[] bean value");
+        return false;
     }
 
     /**


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This makes Recorder ignore unsupported jmx datatypes by default, although they will still be logged. I tested this version with cratedb 4.2, 4.3 and 4.4 and it works. 

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
