### PR TITLE
Use pid from testCluster server

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -2,6 +2,6 @@ prometheus_lib=0.5.0
 
 # test dependencies
 junit=4.12
-crate_testing=0.9.1
+crate_testing=0.10.0
 randomizedtesting=2.1.11
 hamcrest=1.3


### PR DESCRIPTION
Iterating over running JVM apps and taking the first one that is named
`CrateDB` is error prone. It could pick-up a foreign CrateDB instance
that was already running on a machine instead of the one spawned by the
test layer.