### PR TITLE
Use in-memory ascii-armored keys instead of using the gpg agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -195,6 +195,8 @@ publishing {
 }
 
 signing {
-    useGpgCmd()
+    def signingKey = findProperty("signingKey")
+    def signingPassword = findProperty("signingPassword")
+    useInMemoryPgpKeys(signingKey, signingPassword)
     sign(publishing.publications)
 }


### PR DESCRIPTION
Depends on https://github.com/crate/jenkins-dsl/pull/1250