### PR TITLE
Add schema to NodeInfo/ShardInfo

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig: http://editorconfig.org/
+
+root = true
+
+[*]
+insert_final_newline = true
+
+[*.txt]
+charset = utf-8
+
+[*.java]
+charset = utf-8
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@
 Unreleased
 ==========
 
+- Added a ``schema`` property to the ``crate_node{name="shard_info"}`` metrics.
+
 2024/04/25 1.1.0
 ================
 

--- a/src/main/java/io/crate/jmx/recorder/NodeInfo.java
+++ b/src/main/java/io/crate/jmx/recorder/NodeInfo.java
@@ -22,14 +22,15 @@
 
 package io.crate.jmx.recorder;
 
-import io.prometheus.client.Collector;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 import javax.management.openmbean.CompositeData;
-import java.util.List;
-import java.util.Set;
-import java.util.Arrays;
-import java.util.Locale;
-import java.util.Collections;
+
+import io.prometheus.client.Collector;
 
 
 public class NodeInfo implements Recorder {
@@ -72,17 +73,30 @@ public class NodeInfo implements Recorder {
             String table = (String) compositeData.get("table");
             Long size = (Long) compositeData.get("size");
             String partitionIdent = (String) compositeData.get("partitionIdent");
-
-            metricSampleConsumer.accept(
-                    new Collector.MetricFamilySamples.Sample(
-                            domain + '_' + "node",
-                            List.of("name", "property", "id", "table", "partition_ident"),
-                            Arrays.asList("shard_info", "size", shardId.toString(), table, partitionIdent),
-                            size
-                    ),
-                    Collector.Type.GAUGE,
-                    "Information for Shards located on the Node."
-            );
+            if (compositeData.containsKey("schema")) {
+                String schema  = (String) compositeData.get("schema");
+                metricSampleConsumer.accept(
+                      new Collector.MetricFamilySamples.Sample(
+                              domain + '_' + "node",
+                              List.of("name", "property", "id", "schema", "table", "partition_ident"),
+                              Arrays.asList("shard_info", "size", shardId.toString(), schema, table, partitionIdent),
+                              size
+                      ),
+                      Collector.Type.GAUGE,
+                      "Information for Shards located on the Node."
+                );
+            } else {
+                metricSampleConsumer.accept(
+                      new Collector.MetricFamilySamples.Sample(
+                              domain + '_' + "node",
+                              List.of("name", "property", "id", "table", "partition_ident"),
+                              Arrays.asList("shard_info", "size", shardId.toString(), table, partitionIdent),
+                              size
+                      ),
+                      Collector.Type.GAUGE,
+                      "Information for Shards located on the Node."
+                );
+            }
         }
         return true;
     }


### PR DESCRIPTION
See https://github.com/crate/crate/pull/16456 for details

```
↪ http localhost:8070 G shard_info
crate_node{name="shard_info",property="size",id="1",schema="s2",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="2",schema="s2",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="3",schema="s2",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="0",schema="s2",table="tbl",partition_ident="",} 208.0
crate_node{name="shard_info",property="size",id="1",schema="s1",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="2",schema="s1",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="3",schema="s1",table="tbl",partition_ident="",} 0.0
crate_node{name="shard_info",property="size",id="0",schema="s1",table="tbl",partition_ident="",} 208.0
```