### PR TITLE
Dependencies: Update to crate-testing 0.12.1

### DIFF
--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -2,6 +2,6 @@ prometheus_lib=0.16.0
 
 # test dependencies
 junit=4.13.2
-crate_testing=0.11.1
+crate_testing=0.12.1
 randomizedtesting=2.8.1
 hamcrest=2.2


### PR DESCRIPTION
## About
The package `io.crate:crate-testing` has been released in version 0.12.1, which includes this update:
- https://github.com/crate/crate-java-testing/pull/87

