### PR TITLE
Don't send both Content-Length and Transfer-Encoding headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
  Changes for Crate JMX HTTP Exporter
 =====================================
 
+Unreleased
+==========
+
+- Fixed an issue that caused both ``Content-Length`` and ``Transfer-Encoding:
+  chunked`` headers to be set for responses on the ``/metrics`` endpoint.
+  This could cause issues if using the jmx-exporter behind a NGINX proxy or
+  other strict clients.
+
+
 2024/08/20 1.2.0
 ================
 


### PR DESCRIPTION
Per https://www.ietf.org/rfc/rfc2616.txt:

    3.If a Content-Length header field (section 14.13) is present, its
       decimal value in OCTETs represents both the entity-length and the
       transfer-length. The Content-Length header field MUST NOT be sent
       if these two lengths are different (i.e., if a Transfer-Encoding
       header field is present). If a message is received with both a
       Transfer-Encoding header field and a Content-Length header field,
       the latter MUST be ignored.

See also:

- https://docs.oracle.com/en/java/javase/11/docs/api/jdk.httpserver/com/sun/net/httpserver/HttpExchange.html
- https://docs.oracle.com/en/java/javase/11/docs/api/jdk.httpserver/com/sun/net/httpserver/HttpExchange.html#sendResponseHeaders(int,long)

In particular:

    getResponseHeaders() to set any response headers, except content-length

Sending both caused errors when using a nginx proxy in front of the
metrics endpoint:

     upstream sent "Content-Length" and "Transfer-Encoding" headers at the same time while reading response header from upstream,
