### PR TITLE
Fix the Ready handler to not scrape unused/slow MBeans

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,9 @@ Unreleased
   This could cause issues if using the jmx-exporter behind a NGINX proxy or
   other strict clients.
 
+- Fixed an issue that caused the ``/ready`` endpoint to respond slowly if the
+  CrateDB node holds a lot of tables/shards.
+
 
 2024/08/20 1.2.0
 ================

--- a/src/main/java/io/crate/jmx/http/HttpReadyHandler.java
+++ b/src/main/java/io/crate/jmx/http/HttpReadyHandler.java
@@ -46,7 +46,7 @@ public class HttpReadyHandler implements HttpHandler {
     public void handle(HttpExchange exchange) throws IOException {
         // collect crate jmx values
         attributeValueStorage.reset();
-        crateCollector.collect();
+        crateCollector.collect("type=NodeStatus");
 
         exchange.getResponseHeaders().set("Content-Length", "0");
 


### PR DESCRIPTION
Only the `NodeStatus` MBean needs to be scraped by the /ready handler, scraping all can result in slow response times especially when the CrateDB nodes holds a lot of tables/shards.

We've experience this (slow ready responses) on a cluster with lot of shards (thanks for highlighting this @WalBeh!). Fast response times for the ready endpoint are especially important as this endpoint is intended to be used by e.g. load-balancers to detect when a node should be removed/added to the pool.
Mostly used in rolling-restart scenarios where a node decommission will switch the `node.sql.read_only` CrateDB setting to `true`. This is the setting exposed by the `/ready` endpoint.