### PR TITLE
Fix sonatype central JAR publishing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -148,6 +148,8 @@ java {
 nexusPublishing {
     repositories {
         sonatype {
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
             username = project.hasProperty('sonatypeTokenUsername') ? sonatypeTokenUsername : ""
             password = project.hasProperty('sonatypeTokenPassword') ? sonatypeTokenPassword : ""
         }
@@ -183,15 +185,6 @@ publishing {
                     developerConnection = 'scm:git:ssh:git@github.com:crate/jmx_exporter.git'
                     url = 'http://example.com/my-library/'
                 }
-            }
-        }
-    }
-    repositories {
-        maven {
-            url = 'https://oss.sonatype.org/service/local/staging/deploy/maven2/'
-            credentials {
-                username = project.hasProperty('sonatypeUsername') ? sonatypeUsername : ""
-                password = project.hasProperty('sonatypePassword') ? sonatypePassword : ""
             }
         }
     }


### PR DESCRIPTION
The OSSRH has reached EOL, new urls must be used to publish the the Maven Central Portal instead.
See https://central.sonatype.org/pages/ossrh-eol/

Removed the publishing.repostiories section as this is not used and needed when using the nexus.publish plugin.

I've verified these changes (was somehow forced too ;) while publishing yesterday's `1.2.1` release.